### PR TITLE
fix: meweb request count shows 0 due to Prometheus job name mismatch #24

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -23,7 +23,7 @@ class Settings(BaseSettings):
     app_boundaries: str = '{"evm": ["evm-backend", "evm-frontend", "evm-db"], "equicalendar": ["equicalendar"], "planespotter": ["planespotter-api", "planespotter-frontend", "planespotter-sync", "planespotter-db", "planespotter-cache"], "meweb": ["meweb"], "greenscope": ["greenscope"]}'
 
     # App request jobs — JSON string mapping app name to Prometheus job name
-    app_request_jobs: str = '{"evm": "evm-backend", "equicalendar": "equicalendar", "planespotter": "planespotter-api", "meweb": "meweb", "greenscope": "greenscope"}'
+    app_request_jobs: str = '{"evm": "evm-backend", "equicalendar": "equicalendar", "planespotter": "planespotter-api", "meweb": "caddy", "greenscope": "greenscope"}'
 
     # App display names — JSON string mapping internal name to friendly name
     app_display_names: str = '{"evm": "Equestrian Venue Manager", "equicalendar": "EquiCalendar", "planespotter": "Planespotter", "meweb": "dreamfold.dev", "greenscope": "GreenScope"}'


### PR DESCRIPTION
## Summary

- Fixed `app_request_jobs` mapping for meweb: changed Prometheus job name from `"meweb"` to `"caddy"` to match the actual scrape target in `prometheus.yml`
- Updated `meWeb/site/.env.example` with the corrected value

The Caddy metrics are scraped under `job_name: 'caddy'`, but the config was querying for `job="meweb"`, causing `caddy_http_requests_total{job="meweb"}` to return no data.

## Test plan

- [x] Verified `caddy_http_requests_total{job="caddy"}` returns data in Prometheus
- [x] Updated production `.env` and recreated container — dreamfold.dev now shows 393 reqs
- [x] GreenScope app also confirmed working (2 reqs with SCI score)